### PR TITLE
Replace obsolete python-imaging wih python-pil

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ sudo \
         unzip           \
         imagemagick     \
         cpanminus       \
-        python-imaging  \
+        python-pil      \
         perltidy        \
         carton          \
         gdal-bin


### PR DESCRIPTION
The package python-imaging is no longer available in Ubuntu 18.xx.  It has been replaced by python-pil.